### PR TITLE
Hyperlink DOI contra resolvedor preferido

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -65,7 +65,7 @@
 % Comandos auxiliares --> \nomecomando{COMANDO}{•}
 \newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}} % Tabelas: {|C{2cm}|C{5cm}|}
 \newcolumntype{L}[1]{>{\let\newline\\\arraybackslash\hspace{0pt}}m{#1}} % Tabelas: {|L{2cm}|L{5cm}|}
-\newcommand*{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}} % Usado nas referencias
+\newcommand*{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}} % Usado nas referencias
 
 \setcounter{secnumdepth}{3} % Inclui a numeração de \subsubsection{•} no documento
 \setcounter{tocdepth}{3}    % Inclui a \subsubsection{•} no sumário


### PR DESCRIPTION
Olá :-)

A fundação DOI recomenda [este novo e seguro resolvedor](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Assim, este PR atualiza os links DOI estáticos e o código que gera novos.

Felicidades!

--- Google translate ;-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.